### PR TITLE
Change pedestals fluid-xp conversions.

### DIFF
--- a/kubejs/server_scripts/mod_specific/pedestals.js
+++ b/kubejs/server_scripts/mod_specific/pedestals.js
@@ -12,7 +12,7 @@ onEvent(`recipes`, e => {
     `dropper`,
     `magnet`
   ];
-
+  
   coinRF.forEach(name => {
     e.custom({
       type: `allthemodium:atmshapeless_crafting`,
@@ -33,11 +33,11 @@ onEvent(`recipes`, e => {
       result: Item.of(`pedestals:coin/xp${name}`).toResultJson()
     });
   });
-
+  
   e.remove({
     output: `pedestals:dustflour`
   });
-
+  
   const pedestalCrush = (result, count, ingredient) => {
     e.custom({
       type: `pedestals:pedestal_crushing`,
@@ -45,7 +45,7 @@ onEvent(`recipes`, e => {
       result: Item.of(result, count).toResultJson(),
     });
   };
-
+  
   const pedestalSaw = (result, count, ingredient) => {
     e.custom({
       type: `pedestals:pedestal_sawing`,
@@ -96,4 +96,48 @@ onEvent(`recipes`, e => {
   pedestalSaw(`thermal:sawdust`, 1, `#forge:rods/wooden`);
   pedestalSaw(`minecraft:stick`, 4, `#minecraft:planks`);
   pedestalSaw(`minecraft:stick`, 2, `#minecraft:wooden_slabs`);
-});
+  
+  e.remove({id: 'pedestals:pedestal_fluid_to_xp/if_essence_to_xp'});
+  e.remove({id: 'pedestals:pedestal_fluid_to_xp/lava_to_xp'});
+  
+
+  // With default settings, cyclic appears to use a 91/1 ratio here.
+  // This already created a kind of fluid xp loop which is very hard
+  // to fix, so we simply do our best to not make it worse.
+  const expMappings = [
+    ['industrialforegoing:essence_bucket', 91],
+    ['cyclic:xpjuice_bucket', 91],
+    ['integrateddynamics:bucket_menril_resin', 60],
+    ['bloodmagic:life_essence_bucket', 60], // Some automation can make this a double tap, so it's not 1:1 with xp.
+    ['minecraft:lava_bucket', 5], // Since lava is trivially infinite, make it even less profitable.
+  ]
+
+  const registerPedestalsFluidConversion = function(tup) {
+    const id  = tup[0];
+    const amt = tup[1];
+
+    if( id != null && amt != null ) {
+      e.custom({
+        type: 'pedestals:pedestal_fluid_to_xp',
+        ingredient: {
+          item: id
+        },
+        result: {
+          item: "minecraft:experience_bottle",
+          count: amt
+        },
+      });
+    } else {
+      console.warn('Skipped invalid recipe for Pedestals fluid conversion')
+    }
+  };
+
+  expMappings.forEach(registerPedestalsFluidConversion);
+
+  });
+  
+  // Limit Break Pedestals, since this is a skyblock pack anyways.
+  onEvent('item.tags', event => {
+    event.get('pedestals:enchant_limits/advanced_blacklist').remove('pedestals:coin/xpanvil')
+  });
+  


### PR DESCRIPTION
Pedestals config changes:

* Remove the default fluid->xp conversion recipes.
* Add fluid xp conversion for menril, fluid xps, and blood magic essence
* Significantly nerf Lava's XP value since it's so trivially available in this pack.
* Limit break the xp anvil.

The Lava change, as I test it, makes it so that it's possible to save up enough xp for some low level enchants, but effectively impossible to use lava for significant XP gain.

This change has the implication of turning Blood Magic wells of suffering and Sacrifice setups into substantial sources of EXP for enchanting. It also incentivizes a large menril squeezing farm for enchantments as well.